### PR TITLE
:bug: Running `maid run-all-task` at the first time, it fails

### DIFF
--- a/.idea/dictionaries/ryotan.xml
+++ b/.idea/dictionaries/ryotan.xml
@@ -9,6 +9,7 @@
       <w>ddisable</w>
       <w>dharma</w>
       <w>dmaven</w>
+      <w>drepository</w>
       <w>fqcn</w>
       <w>gitignore</w>
       <w>hankey</w>

--- a/maidfile.md
+++ b/maidfile.md
@@ -136,13 +136,13 @@ mvn -N io.takari:maven:0.7.6:wrapper -Dmaven=3.6.1
 ## run-all-tasks
 
 ```bash
+maid deploy-projects-local
 maid format
 maid clean
 maid verify
 maid verify-without-checks
 maid verify-without-coverage
 maid verify-without-checks-and-coverage
-maid deploy-projects-local
 maid owasp-dependency-check
 maid check-dependency-update
 maid apply-dependency-update


### PR DESCRIPTION
Changed to run `deploy-projects-locally` first, to install `itr0-starter-parent` which `itr0-sandbox` references as parent pom into local m2 repository.

To simulate a real project, `itr0-sandbox` is configured not to refer  `itr0-starter-parent` using relativePath, but only using repositories.

So, the first time, running `maid clean` causes maven error such as "`pw.itr0:itr0-starter-parent:0.0.1-SNAPSHOT` is not found."

To avoid this error, I changed to run `deploy-projects-locally` first, and then, run `clean`.