### PR TITLE
✨(deps): Exclude junit-vintage-engine instead of junit:junit

### DIFF
--- a/selidor-projects/selidor-dependencies/pom.xml
+++ b/selidor-projects/selidor-dependencies/pom.xml
@@ -158,8 +158,8 @@
         <version>${spring-boot.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
According to [Spring Boot Reference](https://docs.spring.io/spring-boot/docs/2.2.2.RELEASE/reference/htmlsingle/#boot-features-testing), there is no need to exclude `junit:junit`. Instead, exclude `org.junit.vintage:junit-vintage-engine` to exclude JUnit 4 support.