### PR TITLE
⬇(deps): Revert DbUnit version to 2.7.0 (database-rider is not compatible)

### DIFF
--- a/selidor-projects/selidor-dependencies/pom.xml
+++ b/selidor-projects/selidor-dependencies/pom.xml
@@ -53,7 +53,7 @@
     <cloudevents-api.version>2.2.0</cloudevents-api.version>
     <checkerframework.version>3.17.0</checkerframework.version>
     <database-rider.version>1.27.0</database-rider.version>
-    <dbunit.version>2.7.2</dbunit.version>
+    <dbunit.version>2.7.0</dbunit.version>
     <doma.boot.version>1.5.0</doma.boot.version>
     <doma.version>2.47.1</doma.version>
     <flyway-dbunit-test.version>6.4.0</flyway-dbunit-test.version>


### PR DESCRIPTION
[database-rider](https://github.com/database-rider/database-rider) is [using commons-collections](https://github.com/database-rider/database-rider/blob/2c6f6b5510ab15513d59e21282b8661a8b39ca9d/rider-junit5/src/main/java/com/github/database/rider/junit5/DBUnitExtension.java#L18) through DbUnit dependency. But DbUnit 2.7.1 [removed commons-collections](http://dbunit.sourceforge.net/changes-report.html#a2.7.1) from dependency.